### PR TITLE
Add investors exchange as market_category

### DIFF
--- a/src/enums.rs
+++ b/src/enums.rs
@@ -19,6 +19,7 @@ pub enum MarketCategory {
     NyseMkt,
     NyseArca,
     BatsZExchange,
+    InvestorsExchange,
     Unavailable,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -336,9 +336,10 @@ named!(parse_message<Message>, do_parse!(
         b'F' => map!(apply!(parse_add_order, true), |order| Body::AddOrder(order)) |
         b'H' => call!(parse_trading_action) |
         b'I' => map!(parse_imbalance_indicator, |pii| Body::Imbalance(pii)) |
-        b'J' => do_parse!(stock: stock >> ref_price: be_u32 >> upper_price: be_u32 >>
-                lower_price: be_u32 >> extension: be_u32 >> (Body::LULDAuctionCollar{
-                stock, ref_price, upper_price, lower_price, extension })) |
+        b'J' => do_parse!(stock: stock >> ref_p: be_u32 >> upper_p: be_u32 >>
+                lower_p: be_u32 >> extension: be_u32 >> (Body::LULDAuctionCollar{
+                stock, ref_price: ref_p.into(), upper_price: upper_p.into(),
+                lower_price: lower_p.into(), extension})) |
         b'K' => map!(parse_ipo_quoting_period, |ip| Body::IpoQuotingPeriod(ip)) |
         b'L' => map!(parse_participant_position, |pp| Body::ParticipantPosition(pp)) |
         b'P' => map!(parse_noncross_trade, |nt| Body::NonCrossTrade(nt)) |

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -275,6 +275,13 @@ pub enum Body {
     DeleteOrder { reference: u64 },
     Imbalance(ImbalanceIndicator),
     IpoQuotingPeriod(IpoQuotingPeriod),
+    LULDAuctionCollar {
+        stock: ArrayString8,
+        ref_price: Price4,
+        upper_price: Price4,
+        lower_price: Price4,
+        extension: u32
+    },
     MwcbDeclineLevel {
         level1: Price8,
         level2: Price8,
@@ -329,6 +336,9 @@ named!(parse_message<Message>, do_parse!(
         b'F' => map!(apply!(parse_add_order, true), |order| Body::AddOrder(order)) |
         b'H' => call!(parse_trading_action) |
         b'I' => map!(parse_imbalance_indicator, |pii| Body::Imbalance(pii)) |
+        b'J' => do_parse!(stock: stock >> ref_price: be_u32 >> upper_price: be_u32 >>
+                lower_price: be_u32 >> extension: be_u32 >> (Body::LULDAuctionCollar{
+                stock, ref_price, upper_price, lower_price, extension })) |
         b'K' => map!(parse_ipo_quoting_period, |ip| Body::IpoQuotingPeriod(ip)) |
         b'L' => map!(parse_participant_position, |pp| Body::ParticipantPosition(pp)) |
         b'P' => map!(parse_noncross_trade, |nt| Body::NonCrossTrade(nt)) |

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -392,6 +392,7 @@ named!(parse_stock_directory<StockDirectory>, do_parse!(
         char!('A') => { |_| MarketCategory::NyseMkt } |
         char!('P') => { |_| MarketCategory::NyseArca } |
         char!('Z') => { |_| MarketCategory::BatsZExchange } |
+        char!('V') => { |_| MarketCategory::InvestorsExchange } |
         char!(' ') => { |_| MarketCategory::Unavailable }
     ) >>
     financial_status: alt!(


### PR DESCRIPTION
Adding a new market_category for Investors Exchange, LLC as seen on page 4 of the ITCH specification: https://www.nasdaqtrader.com/content/technicalsupport/specifications/dataproducts/NQTVITCHspecification.pdf

I'm extremely new to Rust, but this clears up a parsing error that occurs when the market category char is `V`, which I'm assuming was recently added.