### PR TITLE
add cross type & etp flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,9 +9,12 @@ license = "MIT"
 edition = "2018"
 
 [dependencies]
-arrayvec = { version = "0.5", features = ["serde"] }
+arrayvec = "0.5"
 decimal = "2.0"
 error-chain = "0.12"
 flate2 = "1.0"
 nom = "4.2"
-serde = { version = "1.0", features = ["derive"] }
+serde = { version = "1.0", optional = true, features = ["derive"] }
+
+[features]
+serde = [ "dep:serde", "arrayvec/serde" ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,9 @@ license = "MIT"
 edition = "2018"
 
 [dependencies]
-arrayvec = "0.5"
+arrayvec = { version = "0.5", features = ["serde"] }
 decimal = "2.0"
 error-chain = "0.12"
 flate2 = "1.0"
 nom = "4.2"
+serde = { version = "1.0", features = ["derive"] }

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -1,7 +1,7 @@
 use nom::{be_u8, IResult};
-use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum EventCode {
     StartOfMessages,
     StartOfSystemHours,
@@ -11,7 +11,8 @@ pub enum EventCode {
     EndOfMessages,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MarketCategory {
     NasdaqGlobalSelect,
     NasdaqGlobalMarket,
@@ -24,7 +25,8 @@ pub enum MarketCategory {
     Unavailable,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FinancialStatus {
     Normal,
     Deficient,
@@ -39,7 +41,8 @@ pub enum FinancialStatus {
     Unavailable,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum IssueClassification {
     AmericanDepositaryShare,
     Bond,
@@ -84,7 +87,8 @@ pub(crate) fn parse_issue_classification(input: &[u8]) -> IResult<&[u8], IssueCl
     })
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum IssueSubType {
     PreferredTrustSecurities,
     AlphaIndexETNs,
@@ -213,14 +217,16 @@ pub(crate) fn parse_issue_subtype(input: &[u8]) -> IResult<&[u8], IssueSubType> 
     })
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LuldRefPriceTier {
     Tier1,
     Tier2,
     Na,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MarketMakerMode {
     Normal,
     Passive,
@@ -229,7 +235,8 @@ pub enum MarketMakerMode {
     Penalty,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MarketParticipantState {
     Active,
     Excused,
@@ -238,14 +245,16 @@ pub enum MarketParticipantState {
     Deleted,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RegShoAction {
     None,
     Intraday,
     Extant,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TradingState {
     Halted,
     Paused,
@@ -253,13 +262,15 @@ pub enum TradingState {
     Trading,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Side {
     Buy,
     Sell,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ImbalanceDirection {
     Buy,
     Sell,
@@ -267,7 +278,8 @@ pub enum ImbalanceDirection {
     InsufficientOrders,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CrossType {
     Opening,
     Closing,
@@ -276,20 +288,23 @@ pub enum CrossType {
     ExtendedTradingClose,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum IpoReleaseQualifier {
     Anticipated,
     Cancelled,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LevelBreached {
     L1,
     L2,
     L3,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum InterestFlag {
     RPIAvailableBuySide,
     RPIAvailableSellSide,

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -272,6 +272,7 @@ pub enum CrossType {
     Closing,
     IpoOrHalted,
     Intraday,
+    ExtendedTradingClose,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -1,6 +1,7 @@
 use nom::{be_u8, IResult};
+use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum EventCode {
     StartOfMessages,
     StartOfSystemHours,
@@ -10,7 +11,7 @@ pub enum EventCode {
     EndOfMessages,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum MarketCategory {
     NasdaqGlobalSelect,
     NasdaqGlobalMarket,
@@ -23,7 +24,7 @@ pub enum MarketCategory {
     Unavailable,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum FinancialStatus {
     Normal,
     Deficient,
@@ -38,7 +39,7 @@ pub enum FinancialStatus {
     Unavailable,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum IssueClassification {
     AmericanDepositaryShare,
     Bond,
@@ -83,7 +84,7 @@ pub(crate) fn parse_issue_classification(input: &[u8]) -> IResult<&[u8], IssueCl
     })
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum IssueSubType {
     PreferredTrustSecurities,
     AlphaIndexETNs,
@@ -212,14 +213,14 @@ pub(crate) fn parse_issue_subtype(input: &[u8]) -> IResult<&[u8], IssueSubType> 
     })
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum LuldRefPriceTier {
     Tier1,
     Tier2,
     Na,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum MarketMakerMode {
     Normal,
     Passive,
@@ -228,7 +229,7 @@ pub enum MarketMakerMode {
     Penalty,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum MarketParticipantState {
     Active,
     Excused,
@@ -237,14 +238,14 @@ pub enum MarketParticipantState {
     Deleted,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum RegShoAction {
     None,
     Intraday,
     Extant,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum TradingState {
     Halted,
     Paused,
@@ -252,13 +253,13 @@ pub enum TradingState {
     Trading,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum Side {
     Buy,
     Sell,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ImbalanceDirection {
     Buy,
     Sell,
@@ -266,7 +267,7 @@ pub enum ImbalanceDirection {
     InsufficientOrders,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum CrossType {
     Opening,
     Closing,
@@ -275,20 +276,20 @@ pub enum CrossType {
     ExtendedTradingClose,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum IpoReleaseQualifier {
     Anticipated,
     Cancelled,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum LevelBreached {
     L1,
     L2,
     L3,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum InterestFlag {
     RPIAvailableBuySide,
     RPIAvailableSellSide,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -250,6 +250,16 @@ named!(
 );
 
 named!(
+    parse_etp_flag<Option<bool>>,
+    alt!(
+        char!('Y') => {|_| Some(true)} |
+        char!('N') => {|_| Some(false)} |
+        char!(' ') => {|_| None} |
+        char!('M') => {|_| Some(true)}
+    )
+);
+
+named!(
     stock<ArrayString8>,
     map!(take_str!(8), |s| ArrayString::from(s).unwrap())
 );
@@ -506,7 +516,7 @@ named!(
                 char!('1') => { |_| LuldRefPriceTier::Tier1 } |
                 char!('2') => { |_| LuldRefPriceTier::Tier2 }
             )
-            >> etp_flag: maybe_char2bool
+            >> etp_flag: parse_etp_flag
             >> etp_leverage_factor: be_u32
             >> inverse_indicator: char2bool
             >> (StockDirectory {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -733,7 +733,8 @@ named!(
                 char!('O') => {|_| CrossType::Opening} |
                 char!('C') => {|_| CrossType::Closing} |
                 char!('H') => {|_| CrossType::IpoOrHalted} |
-                char!('I') => {|_| CrossType::Intraday}
+                char!('I') => {|_| CrossType::Intraday} |
+                char!('A') => {|_| CrossType::ExtendedTradingClose}
             )
             >> (CrossTrade {
                 shares,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,7 @@ extern crate decimal;
 extern crate flate2;
 
 pub use decimal::d128;
+use serde::{Serialize, Deserialize};
 use std::fmt;
 use std::fs::File;
 use std::io::prelude::*;
@@ -202,7 +203,7 @@ impl<R: Read> Iterator for MessageStream<R> {
 }
 
 /// Opaque type representing a price to four decimal places
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Price4(u32);
 
 impl Price4 {
@@ -224,7 +225,7 @@ impl From<u32> for Price4 {
 }
 
 /// Opaque type representing a price to eight decimal places
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Price8(u64);
 
 impl Price8 {
@@ -307,7 +308,7 @@ pub struct Message {
 }
 
 /// The message body. Refer to the protocol spec for interpretation.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum Body {
     AddOrder(AddOrder),
     Breach(LevelBreached),
@@ -451,7 +452,7 @@ named!(
     )
 );
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct StockDirectory {
     pub stock: ArrayString8,
     pub market_category: MarketCategory,
@@ -550,7 +551,7 @@ named!(
     )
 );
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct MarketParticipantPosition {
     pub mpid: ArrayString4,
     pub stock: ArrayString8,
@@ -617,7 +618,7 @@ named!(
     )
 );
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct AddOrder {
     pub reference: u64,
     pub side: Side,
@@ -653,7 +654,7 @@ fn parse_add_order(input: &[u8], attribution: bool) -> IResult<&[u8], AddOrder> 
     )
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ReplaceOrder {
     pub old_reference: u64,
     pub new_reference: u64,
@@ -677,7 +678,7 @@ named!(
     )
 );
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ImbalanceIndicator {
     pub paired_shares: u64,
     pub imbalance_shares: u64,
@@ -725,7 +726,7 @@ named!(
     )
 );
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct CrossTrade {
     pub shares: u64,
     pub stock: ArrayString8,
@@ -759,7 +760,7 @@ named!(
 );
 
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct RetailPriceImprovementIndicator {
     pub stock: ArrayString8,
     pub interest_flag: InterestFlag,
@@ -782,7 +783,7 @@ named!(
     )
 );
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct NonCrossTrade {
     pub reference: u64,
     pub side: Side,
@@ -815,7 +816,7 @@ named!(
     )
 );
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct IpoQuotingPeriod {
     pub stock: ArrayString8,
     pub release_time: u32,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -205,6 +205,12 @@ impl<R: Read> Iterator for MessageStream<R> {
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct Price4(u32);
 
+impl Price4 {
+    pub fn raw(self) -> u32 {
+        self.0
+    }
+}
+
 impl Into<d128> for Price4 {
     fn into(self) -> d128 {
         d128::from(self.0) / d128::from(10_000)
@@ -220,6 +226,12 @@ impl From<u32> for Price4 {
 /// Opaque type representing a price to eight decimal places
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct Price8(u64);
+
+impl Price8 {
+    pub fn raw(self) -> u64 {
+        self.0
+    }
+}
 
 impl Into<d128> for Price8 {
     fn into(self) -> d128 {


### PR DESCRIPTION
Hi!

Nasdaq added "Extended Trading Close" to the "Cross Type" field under NOII message on Jan 7, 2022.
So I add some code to reflect this change.

Also, I found ETF_FLAG with the value 'M' when I process the file named S020216-v50.txt.gz file.
I asked Nasdaq about this problem via E-mail and Nasdaq said that this should be considered as 'Y'.
So I added the branch that handles ETP Flag 'M'. 
I think it is acceptable because it doesn't degrade the performance of parsing even though there is no ETF Flag with the value 'M'.