### PR TITLE
Update nom to v6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ arrayvec = "0.7.2"
 decimal = "2.0"
 error-chain = "0.12"
 flate2 = "1.0"
-nom = "6"
+nom = "6.2.2"
 serde = { version = "1.0", optional = true, features = ["derive"] }
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,9 @@ arrayvec = "0.7.2"
 decimal = "2.0"
 error-chain = "0.12"
 flate2 = "1.0"
-nom = "4.2"
+# nom = "4.2"
+nom = "5"
 serde = { version = "1.0", optional = true, features = ["derive"] }
 
 [features]
-serde = [ "dep:serde", "arrayvec/serde" ]
+serde = ["dep:serde", "arrayvec/serde"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,7 @@ arrayvec = "0.7.2"
 decimal = "2.0"
 error-chain = "0.12"
 flate2 = "1.0"
-# nom = "4.2"
-nom = "5"
+nom = "6"
 serde = { version = "1.0", optional = true, features = ["derive"] }
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "itchy"
 authors = ["Alex Whitney <adwhit@fastmail.com>"]
-version = "0.2.3"
+version = "0.2.4"
 description = "Nom-based parser library for NASDAQ ITCH protocol"
 repository = "https://github.com/adwhit/itchy-rust"
 keywords = ["nasdaq", "itch", "nom"]

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -1,4 +1,4 @@
-use nom::{be_u8, IResult};
+use nom::{number::complete::be_u8, IResult};
 
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]


### PR DESCRIPTION
Hi, the crate currently uses `nom` v4, which has a deprecation warning when compiled:

![image](https://github.com/user-attachments/assets/08af308e-9706-4106-b2e9-10a37c03b1d9)

This PR:
* Updates `nom` to v6
* Adds `clippy` fixes