### PR TITLE
Update to nom v7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 [dependencies]
 arrayvec = "0.7.6"
 flate2 = "1.0"
-nom = "6.2.2"
+nom = "7.1.3"
 rust_decimal = { version = "1.36.0", default-features = false }
 serde = { version = "1.0", optional = true, features = ["derive"] }
 thiserror = "1"

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -1,4 +1,4 @@
-use nom::{number::complete::be_u8, IResult};
+use nom::{bytes::streaming::take, combinator::map_opt, number::streaming::be_u8, IResult};
 
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -63,7 +63,7 @@ pub enum IssueClassification {
 }
 
 pub(crate) fn parse_issue_classification(input: &[u8]) -> IResult<&[u8], IssueClassification> {
-    map_opt!(input, be_u8, |v| {
+    map_opt(be_u8, |v| {
         use IssueClassification::*;
         Some(match v {
             b'A' => AmericanDepositaryShare,
@@ -84,7 +84,7 @@ pub(crate) fn parse_issue_classification(input: &[u8]) -> IResult<&[u8], IssueCl
             b'W' => Warrant,
             _ => return None,
         })
-    })
+    })(input)
 }
 
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -151,8 +151,9 @@ pub enum IssueSubType {
 }
 
 pub(crate) fn parse_issue_subtype(input: &[u8]) -> IResult<&[u8], IssueSubType> {
-    map_opt!(input, take!(2), |v: &[u8]| {
+    map_opt(take(2usize), |v: &[u8]| {
         use IssueSubType::*;
+
         Some(match v {
             b"A " => PreferredTrustSecurities,
             b"AI" => AlphaIndexETNs,
@@ -214,7 +215,7 @@ pub(crate) fn parse_issue_subtype(input: &[u8]) -> IResult<&[u8], IssueSubType> 
             b"Z " => NotApplicable,
             _ => return None,
         })
-    })
+    })(input)
 }
 
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]


### PR DESCRIPTION
This PR updates `nom`  to version 7.

Unfortunately, the macro API (which is used in this project) is deprecated but the migration is quite straightforward.
