### PR TITLE
Add 'get_mut' to stream for mutable reference to underlying stream.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -147,6 +147,11 @@ impl<R: Read> MessageStream<R> {
     pub fn get_ref(&self) -> &R {
         &self.reader
     }
+
+    /// Returns a mutable reference to the underlying reader.
+    pub fn get_mut(&mut self) -> &mut R {
+        &mut self.reader
+    }
 }
 
 impl<R: Read> Iterator for MessageStream<R> {


### PR DESCRIPTION
This PR adds `MessageStream::get_mut` to complete the previously added `MessageStream::get_ref`.

I bumped into this because getting the cursor position in a file handle [currently requires a mut reference](https://github.com/rust-lang/rust/issues/59359#issuecomment-1763475845).